### PR TITLE
Fix Trickster Takeover scenario issue #26

### DIFF
--- a/cards/pack/tt/god_of_lies/55052.py
+++ b/cards/pack/tt/god_of_lies/55052.py
@@ -3,11 +3,7 @@ from . import *
 
 def GetAbilities() -> Sequence['Ability']:
     def attack(effect: 'Effect', message: 'Message.WhenUnitWouldAttack') -> None:
-        message.trigger.CastTo(Unit2).GainForThisActive(
-            effect,
-            message,
-            attack=4,
-        )
+        message.DealAdditionalDamage(4, effect)
 
     return [
         AbilityFactory.WhenUnitWouldAttack(

--- a/cards/pack/tt/god_of_lies/55054.py
+++ b/cards/pack/tt/god_of_lies/55054.py
@@ -3,11 +3,7 @@ from . import *
 
 def GetAbilities() -> Sequence['Ability']:
     def thwart(effect: 'Effect', message: 'Message.WhenUnitWouldThwart') -> None:
-        message.trigger.CastTo(Unit2).GainForThisActive(
-            effect,
-            message,
-            thwart=4,
-        )
+        message.RemoveAdditionalThreat(4, effect)
 
     return [
         AbilityFactory.WhenUnitWouldThwart(

--- a/cards/pack/tt/god_of_lies/__init__.py
+++ b/cards/pack/tt/god_of_lies/__init__.py
@@ -117,6 +117,7 @@ def _swap_physical_avatar(
     fading: 'Villain',
     next_avatar: 'Villain',
     effect: 'Effect',
+    reset_health: bool = True
 ) -> 'Villain':
     """Swap both faces of two physical avatar cards while retaining attachments."""
     active_card = fading.card
@@ -144,7 +145,8 @@ def _swap_physical_avatar(
     old_front.card = aside_card
     old_fading.card = aside_card
 
-    new_front.ResetHealth(effect)
+    if reset_health:
+        new_front.ResetHealth(effect)
     for attachment in new_front.GetAttachedAttachments():
         if attachment.IsName("Intense Focus"):
             bonus = Worlds.ConvertPerPlayerIconToInt("2*", effect)
@@ -168,7 +170,7 @@ def SwapAvatarWithRandomSetAside(effect: 'Effect') -> 'Villain|None':
     # card to its illusion face only long enough to use the same safe swap path.
     active.card.Flip(effect, call_reveal=False)
     fading = active.card.face.CastTo(Villain)
-    return _swap_physical_avatar(fading, next_avatar, effect)
+    return _swap_physical_avatar(fading, next_avatar, effect, reset_health=False)
 
 
 def ShatterTheIllusion(effect: 'Effect') -> None:

--- a/data/cards.json
+++ b/data/cards.json
@@ -56558,7 +56558,7 @@
             "subtitle": "",
             "desc": {
                 "StartingThreat": "4",
-                "Hazard": "1",
+                "Crisis": "1",
                 "Boost": "1"
             },
             "traits": [],
@@ -56602,7 +56602,7 @@
             "subtitle": "",
             "desc": {
                 "StartingThreat": "6",
-                "Crisis": "1",
+                "Acceleration": "1",
                 "Boost": "3"
             },
             "traits": [],


### PR DESCRIPTION
Fixes #26.

- 55051: preserve Loki's HP when swapping avatars.
- 55045 / 55048: fix side scheme icons.
- 55052 / 55054: fix additional attack/thwart bonuses.