### PR TITLE
#28 Fix Enchantress charm counter

### DIFF
--- a/cards/pack/tt/enchantress/55003.py
+++ b/cards/pack/tt/enchantress/55003.py
@@ -22,5 +22,6 @@ def GetAbilities() -> Sequence['Ability']:
             None,
             enchantress_revealed
         ),
+        AfterEnchantressAttacksYouPlaceCharmCounter(),
     ]
 


### PR DESCRIPTION
Fixes #28

Enchantress III was missing the forced response that places 1 charm counter after she attacks.

Added `AfterEnchantressAttacksYouPlaceCharmCounter()` to `55003.py`.

Tested with Enchantress III, including an attack triggered by Spell Blast.