### PR TITLE
#24 Fix Blindfold encounter card order

### DIFF
--- a/public/js/marvel/cards.ts
+++ b/public/js/marvel/cards.ts
@@ -210,7 +210,7 @@ class CardRender {
                 return [...areaCards].sort((a, b) => {
                     const aLegal = Effect.select_effect_obj.all_legal_targets.includes(a.object_id);
                     const bLegal = Effect.select_effect_obj.all_legal_targets.includes(b.object_id);
-                    if (aLegal && bLegal) return a.object_id - b.object_id;
+                    if (aLegal && bLegal) return 0;
                     if (aLegal) return 1;
                     if (bLegal) return -1;
                     return 0;


### PR DESCRIPTION
Fixes #24

When Blindfold looks at the top 5 cards of the encounter deck, the selectable cards were displayed sorted by `object_id` instead of preserving their current deck order.

The encounter deck itself was not being shuffled or reordered. After discarding a card, the remaining cards were still in the correct order.

This change preserves the relative order of legal cards while selecting from a deck or discard pile.

### Before

The encounter deck was in the correct order:

<img width="1793" height="808" alt="image" src="https://github.com/user-attachments/assets/6c80d457-6091-436b-aa2e-8d44b86816c0" />

But Blindfold displayed the same cards sorted by `object_id` (cXXX) instead of preserving their deck order:

<img width="1997" height="438" alt="image" src="https://github.com/user-attachments/assets/cd85be4a-18b0-4a18-9d80-00f1ade16ac5" />

After discarding one card, the encounter deck still preserved the correct order:

<img width="1963" height="819" alt="image" src="https://github.com/user-attachments/assets/a8217ea9-5f71-44b6-b1d3-7e7e17f0e463" />

### Tested

- Blindfold now displays the top 5 encounter cards in their actual deck order.
- After discarding one of them, the remaining encounter deck order is preserved.